### PR TITLE
Fix MacOS Icon file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# ignore the MacOS Icon file that breaks everything
+Icon? filter=ignore


### PR DESCRIPTION
Renamed Icon/r file and added ignore for it to .gitattributes . Was breaking non MacOS systems